### PR TITLE
Avoid resolving promise with undefined; always throwing not found error.

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -77,11 +77,8 @@ export default function resolve(id, rawopts) {
 			throw new Error('It\'s not clear which file to import');
 		}
 
-		// otherwise, if `base` does not end with `.css`
-		if (!ends_with_css_extension(base)) {
-			// throw `"File to import not found or unreadable"`
-			throw new Error('File to import not found or unreadable');
-		}
+		// throw `"File to import not found or unreadable"`
+		throw new Error('File to import not found or unreadable');
 	});
 }
 


### PR DESCRIPTION
The core promise can resolve to `undefined` since there is no fallback return / throw statement.

In the (very common) scenario where the import file is (1) correctly formed (ends with `.css`, etc.) but (2) does not exist, the promise will resolve to `undefined` instead of rejecting. This is especially problematic when walking through an array of possible paths where the import might be located, as in `postcss-advanced-variables`'s `importPaths` directive:

https://github.com/jonathantneal/postcss-advanced-variables#importpaths